### PR TITLE
Add Flow TypeCastExpression Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 .idea
 *.swp
+.nyc_output
+.vscode

--- a/lib/ruleHelper.js
+++ b/lib/ruleHelper.js
@@ -77,6 +77,8 @@ RuleHelper.prototype = {
         } else if (expression.type === "TSAsExpression") {
             // TSAsExpressions contain the raw javascript value in 'expression'
             allowed = this.allowedExpression(expression.expression, escapeObject);
+        } else if (expression.type === "TypeCastExpression") {
+            allowed = this.allowedExpression(expression.expression, escapeObject);
         }
         else {
             // everything that doesn't match is unsafe:

--- a/lib/rules/method.js
+++ b/lib/rules/method.js
@@ -67,7 +67,6 @@ function checkImport(ruleHelper, importExpr) {
  * @returns {undefined} Does not return
  */
 function checkCallExpression(ruleHelper, callExpr, node) {
-    console.log(node.type);
     switch(node.type) {
     case "Identifier":
     case "MemberExpression":

--- a/lib/rules/method.js
+++ b/lib/rules/method.js
@@ -67,6 +67,7 @@ function checkImport(ruleHelper, importExpr) {
  * @returns {undefined} Does not return
  */
 function checkCallExpression(ruleHelper, callExpr, node) {
+    console.log(node.type);
     switch(node.type) {
     case "Identifier":
     case "MemberExpression":
@@ -122,6 +123,7 @@ function checkCallExpression(ruleHelper, callExpr, node) {
     case "ThisExpression":
     case "NewExpression":
     case "TSTypeAssertion":
+    case "TypeCastExpression":
     case "AwaitExpression": // see issue #122
         break;
 

--- a/tests/rules/method.js
+++ b/tests/rules/method.js
@@ -268,18 +268,10 @@ eslintTester.run("method", rule, {
         {
             code: "(node: HTMLElement).insertAdjacentHTML('beforebegin', 'raw string');",
             parser: PATH_TO_BABEL_ESLINT,
-            parserOptions: {
-                ecmaVersion: 2018,
-                sourceType: "module",
-            }
         },
         {
             code: "node.insertAdjacentHTML('beforebegin', (5: string));",
             parser: PATH_TO_BABEL_ESLINT,
-            parserOptions: {
-                ecmaVersion: 2018,
-                sourceType: "module",
-            },
         },
 
 

--- a/tests/rules/method.js
+++ b/tests/rules/method.js
@@ -262,6 +262,26 @@ eslintTester.run("method", rule, {
                 sourceType: "module",
             }
         },
+        
+
+        // Flow support tests
+        {
+            code: "(node: HTMLElement).insertAdjacentHTML('beforebegin', 'raw string');",
+            parser: PATH_TO_BABEL_ESLINT,
+            parserOptions: {
+                ecmaVersion: 2018,
+                sourceType: "module",
+            }
+        },
+        {
+            code: "node.insertAdjacentHTML('beforebegin', (5: string));",
+            parser: PATH_TO_BABEL_ESLINT,
+            parserOptions: {
+                ecmaVersion: 2018,
+                sourceType: "module",
+            },
+        },
+
 
         // Issue 135: method calls to import should not warn.
         {

--- a/tests/rules/property.js
+++ b/tests/rules/property.js
@@ -416,6 +416,28 @@ eslintTester.run("property", rule, {
             ]
         },
 
+        // Flow support cases
+        {
+            code: "(x: HTMLElement).innerHTML = htmlString",
+            parser: PATH_TO_BABEL_ESLINT,
+            errors: [
+                {
+                    message: "Unsafe assignment to innerHTML",
+                    type: "AssignmentExpression"
+                }
+            ]
+        },
+        {
+            code: "lol.innerHTML = (foo: string);",
+            parser: PATH_TO_BABEL_ESLINT,
+            errors: [
+                {
+                    message: "Unsafe assignment to innerHTML",
+                    type: "AssignmentExpression"
+                }
+            ]
+        },
+
         // ES2020 support cases
         {
             code: "yoink.innerHTML &&= bar;",


### PR DESCRIPTION
Closes https://github.com/mozilla/eslint-plugin-no-unsanitized/issues/155

Changes to add support for the `TypeCastExpression` ESLint babel node type, which occurs when someone does a Flow type cast.

I added tests that mirror the [TypeScript](https://github.com/mozilla/eslint-plugin-no-unsanitized/pull/137/files) ones but with Flow syntax, let me know if there are any other test cases I should include.

I'm just opening this PR on my fork for the moment as I work on testing these changes on a larger Flow codebase to look for any other issues.